### PR TITLE
Account for url navigate

### DIFF
--- a/app/javascript/react/containers/Callback.js
+++ b/app/javascript/react/containers/Callback.js
@@ -16,23 +16,24 @@ class Callback extends React.Component {
   componentDidMount(){
     const queryString = require('query-string')
     const parsedQuerySearch = queryString.parse(this.props.location.search)
-    if(parsedQuerySearch.error) {
-      this.setState({ error: "You must connect to Spotify in order to user SkyTunes!" });
-    } else {
+    if(parsedQuerySearch.code) {
       userClient.post(parsedQuerySearch.code)
         .then(response => response.json())
         .then(body => storage.set(JWT, body))
         .then(() => this.props.history.push('/track-player'))
-        .catch(error => console.error(`Error in fetch: ${error.message}`));
+        .catch(error => console.error(`Error in fetch: ${error.message}`))
+    } else {
+      this.setState({ error: "You must connect to Spotify in order to user SkyTunes!" });
     }
   }
 
   render() {
     let callBackElement = <div></div>
     if (this.state.error) {
-      callBackElement = <Login
-                          error={this.state.error}
-                        />
+      callBackElement = <div>
+                          <p>{this.state.error}</p>
+                          <a href="/login"><button>OK</button></a>
+                        </div>
     }
 
     return(

--- a/app/javascript/react/containers/Login.js
+++ b/app/javascript/react/containers/Login.js
@@ -1,15 +1,9 @@
 import React from 'react'
 
 const Login = props => {
-  let errorDiv;
-
-  if (props.error) {
-    errorDiv  = <p>{props.error}</p>
-  }
 
   return (
     <div>
-      {errorDiv}
       <a href="/api/v1/login"><button>Log in</button></a>
     </div>
   )


### PR DESCRIPTION
If the user navigates to the /callback path via the url they will get the same error message as if they did not get an authentication code. No longer using Login container on this error page, rather an OK button that sends you to /login.