### PR TITLE
Create separate prod env

### DIFF
--- a/app/assets/stylesheets/navbar.css
+++ b/app/assets/stylesheets/navbar.css
@@ -17,12 +17,7 @@
   color: #F8D6D2;
 }
 
-.nav-new-track.nav-link {
-  position: absolute;
-  right: 1%;
-}
-
 .nav-tracks.nav-link {
   position: absolute;
-  right: 13%;
+  right: 1%;
 }

--- a/app/controllers/api/v1/login_controller.rb
+++ b/app/controllers/api/v1/login_controller.rb
@@ -3,10 +3,16 @@ class Api::V1::LoginController < ApiController
 #include state param when you figure out what it is
 #include scope param later (WILL MAKE SHOW_DIALOG WORK)
   def index
+    if Rails.env.production?
+      redirect_uri = ENV['REDIRECT_URI_PRODUCTION']
+    else
+      redirect_uri = ENV['REDIRECT_URI_DEVELOPMENT']
+    end
+    
     query_params = {
       client_id: ENV['CLIENT_ID'],
       response_type: "code",
-      redirect_uri: ENV['REDIRECT_URI'],
+      redirect_uri: redirect_uri,
       scope: "user-modify-playback-state user-read-playback-state user-read-currently-playing streaming app-remote-control user-read-birthdate user-read-email user-read-private",
       show_dialog: true
     }

--- a/app/controllers/api/v1/user_controller.rb
+++ b/app/controllers/api/v1/user_controller.rb
@@ -1,10 +1,16 @@
 class Api::V1::UserController < ApiController
 
   def create
+    if Rails.env.production?
+      redirect_uri = ENV['REDIRECT_URI_PRODUCTION']
+    else
+      redirect_uri = ENV['REDIRECT_URI_DEVELOPMENT']
+    end
+
     body = {
       grant_type: "authorization_code",
       code: user_params[:code],
-      redirect_uri: ENV['REDIRECT_URI'],
+      redirect_uri: redirect_uri,
       client_id: ENV['CLIENT_ID'],
       client_secret: ENV['CLIENT_SECRET']
     }

--- a/app/javascript/react/components/NavBar.js
+++ b/app/javascript/react/components/NavBar.js
@@ -7,7 +7,6 @@ const NavBar = props => {
       <div className="navbar">
         <Link to='/track-player' className="nav-link">SkyTunes</Link>
         <Link to='/tracks' className="nav-link nav-tracks">My Tracks</Link>
-        <Link to='/tracks/new' className="nav-link nav-new-track">Add New Tracks</Link>
       </div>
       <div>
         {props.children}

--- a/app/javascript/react/containers/TracksIndexContainer.js
+++ b/app/javascript/react/containers/TracksIndexContainer.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import trackClient from '../clients/track';
+import storage from '../util/storage';
+import { USER } from '../constants';
 
 
 class TracksIndexContainer extends React.Component {
@@ -11,6 +13,7 @@ class TracksIndexContainer extends React.Component {
   }
 
   componentDidMount() {
+    const userId = storage.get(USER).id;
     trackClient.get()
       .then(response => response.json())
       .then(body => {

--- a/app/javascript/react/containers/TracksIndexContainer.js
+++ b/app/javascript/react/containers/TracksIndexContainer.js
@@ -14,7 +14,7 @@ class TracksIndexContainer extends React.Component {
 
   componentDidMount() {
     const userId = storage.get(USER).id;
-    trackClient.get()
+    trackClient.get(userId)
       .then(response => response.json())
       .then(body => {
         this.setState({


### PR DESCRIPTION
Created separate env variables for the spotify auth redirect uri for production and development, since in heroku prod it was previously redirecting to a local host path. Removed Add New Tracks from nav bar. Fixed small issue with not passing userId to getTrackClient in TracksIndexContainer.