### PR TITLE
Fetch and display index info

### DIFF
--- a/app/assets/stylesheets/track_index.css
+++ b/app/assets/stylesheets/track_index.css
@@ -1,0 +1,28 @@
+.index-tile {
+  margin-left: 1.5em;
+  margin-right: 1.5em;
+}
+
+.index-tile .wrapper {
+  background: rgba(0, 0, 0, 0.15);
+  box-shadow: 1px 2px 3px rgba(72, 72, 72, 0.15);
+  margin-bottom: .75em;
+  padding-left: 0em;
+
+}
+
+.index-tile .wrapper:hover {
+    cursor: pointer;
+    background: rgba(0, 0, 0, 0.25);
+    box-shadow: 1px 1px 1px rgba(72, 72, 72, 0.88);
+}
+
+.index-tile .wrapper img{
+  width: 4em;
+  height: auto;
+  padding-left: 0em;
+}
+
+.index-tile .wrapper span{
+  padding-top: 0.8rem;
+}

--- a/app/assets/stylesheets/track_index.css
+++ b/app/assets/stylesheets/track_index.css
@@ -8,6 +8,7 @@
   box-shadow: 1px 2px 3px rgba(72, 72, 72, 0.15);
   margin-bottom: .75em;
   padding-left: 0em;
+  color: #171717;
 
 }
 
@@ -25,4 +26,36 @@
 
 .index-tile .wrapper span{
   padding-top: 0.8rem;
+}
+
+.index-labels {
+  margin: 1% 2%;
+  color: #c2c3c5;
+  letter-spacing: 1px;
+}
+
+.index-labels .title {
+  display: inline-block;
+}
+
+.index-labels .title:first-child{
+  margin-left: 4%;
+  padding-left: 22px;
+  width: 35%;
+}
+
+.index-labels .title:nth-child(2){
+  padding-left: 2px;
+  width:24%;
+}
+
+.index-labels .title:nth-child(3){
+  padding-left: 12px;
+  width:24%;
+}
+
+.index-labels .title:last-child{
+  width: 8%;
+  text-align: right;
+  padding-right: 16px;
 }

--- a/app/controllers/api/v1/user_track_categories_controller.rb
+++ b/app/controllers/api/v1/user_track_categories_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::UserTrackCategoriesController < ApiController
 
   def index
-    render json: UserTrackCategory.where({user_id: params[:user_id]})
+    render json: UserTrackCategory.where({user_id: params[:user_id]}).pluck(:track_id).uniq
   end
 
   def create

--- a/app/javascript/react/clients/track.js
+++ b/app/javascript/react/clients/track.js
@@ -1,4 +1,7 @@
+import getDefaultOptions from '../util/getDefaultOptions';
+
 const USER_TRACK_CATEGORY_PATH = '/api/v1/user';
+const SPOTIFY_TRACKS_PATH = 'https://api.spotify.com/v1/tracks';
 
 const defaultOptions = {
   credentials: 'same-origin',
@@ -22,7 +25,12 @@ const get = userId => fetch(
   defaultOptions
 );
 
+const getInfo = trackIds => fetch(`${SPOTIFY_TRACKS_PATH}/?ids=${trackIds}`,
+  getDefaultOptions()
+)
+
 export default {
   post: post,
-  get: get
+  get: get,
+  getInfo: getInfo
 };

--- a/app/javascript/react/components/TrackIndexTile.js
+++ b/app/javascript/react/components/TrackIndexTile.js
@@ -14,18 +14,5 @@ const TrackIndexTile = props => {
   )
 }
 
-// <div className="small-3 small-centered columns">
-//   <div className="row wrapper">
-//     <span className="small-4 columns" onClick={props.onPrevClick}>
-//       <i className="fas fa-step-backward next-prev-icon"></i>
-//     </span>
-//     <span className="small-4 columns" onClick={props.onPlayClick}>
-//       <i className={`${props.playToggleClass} play-icon`}></i>
-//     </span>
-//     <span className="small-4 columns" onClick={props.onNextClick}>
-//       <i className="fas fa-step-forward next-prev-icon"></i>
-//     </span>
-//   </div>
-// </div>
 
 export default TrackIndexTile

--- a/app/javascript/react/components/TrackIndexTile.js
+++ b/app/javascript/react/components/TrackIndexTile.js
@@ -1,0 +1,31 @@
+import React from 'react'
+
+const TrackIndexTile = props => {
+  return (
+    <div className="index-tile">
+      <span className="small-12 columns wrapper">
+        <img className="small-1 columns" src={props.albumCover} alt="album cover" />
+        <span className="small-4 columns">{props.title}</span>
+        <span className="small-3 columns">{props.artists}</span>
+        <span className="small-3 columns">{props.album}</span>
+        <span className="small-1 columns">{props.duration}</span>
+      </span>
+    </div>
+  )
+}
+
+// <div className="small-3 small-centered columns">
+//   <div className="row wrapper">
+//     <span className="small-4 columns" onClick={props.onPrevClick}>
+//       <i className="fas fa-step-backward next-prev-icon"></i>
+//     </span>
+//     <span className="small-4 columns" onClick={props.onPlayClick}>
+//       <i className={`${props.playToggleClass} play-icon`}></i>
+//     </span>
+//     <span className="small-4 columns" onClick={props.onNextClick}>
+//       <i className="fas fa-step-forward next-prev-icon"></i>
+//     </span>
+//   </div>
+// </div>
+
+export default TrackIndexTile

--- a/app/javascript/react/containers/Search.js
+++ b/app/javascript/react/containers/Search.js
@@ -39,6 +39,7 @@ class Search extends React.Component {
  render() {
 
    const resultDiv = this.state.tracks.map(track => {
+     debugger;
      return <SearchResultTile
                key={track.id}
                title={track.name}

--- a/app/javascript/react/containers/TrackPlayer.js
+++ b/app/javascript/react/containers/TrackPlayer.js
@@ -44,7 +44,6 @@ class TrackPlayer extends React.Component {
     const userId = storage.get(USER).id;
     trackClient.get(userId)
       .then(response => response.json())
-      .then(body => body.user_track_categories.map(track => track.track_id))
       .then(trackIds => {
         const trackUris = trackIds.map(trackId => `spotify:track:${trackId}`);
         return playerClient.put(trackUris, deviceId);

--- a/app/javascript/react/containers/TracksIndexContainer.js
+++ b/app/javascript/react/containers/TracksIndexContainer.js
@@ -49,7 +49,12 @@ class TracksIndexContainer extends React.Component {
 
     return(
       <div>
-        <br></br>
+        <div className="index-labels">
+          <span className="title">TITLE</span>
+          <span className="title">ARTIST</span>
+          <span className="title">ALBUM</span>
+          <span className="title"><i className="far fa-clock"></i></span>
+        </div>
         {this.getTrackIndexTiles()}
       </div>
     )

--- a/app/javascript/react/containers/TracksIndexContainer.js
+++ b/app/javascript/react/containers/TracksIndexContainer.js
@@ -1,4 +1,7 @@
 import React from 'react';
+import TrackIndexTile from '../components/TrackIndexTile';
+import convert from '../util/convert';
+import createArtistList from '../util/createArtistList';
 import trackClient from '../clients/track';
 import storage from '../util/storage';
 import { USER } from '../constants';
@@ -10,25 +13,44 @@ class TracksIndexContainer extends React.Component {
     this.state = {
       tracks: []
     }
+
+    this.getTrackIndexTiles = this.getTrackIndexTiles.bind(this);
   }
 
   componentDidMount() {
     const userId = storage.get(USER).id;
     trackClient.get(userId)
       .then(response => response.json())
+      .then(trackIds => trackClient.getInfo(trackIds))
+      .then(response => response.json())
       .then(body => {
         this.setState({
-          tracks: body.user_track_categories
+          tracks: body.tracks
         })
       })
       .catch(error => console.error(`Error in fetch: ${error.message}`));
+  }
+
+  getTrackIndexTiles() {
+    return this.state.tracks.map(track =>
+      <TrackIndexTile
+         key={track.id}
+         id={track.id}
+         title={track.name}
+         artists={createArtistList(track.artists)}
+         album={track.album.name}
+         albumCover={track.album.images[1].url}
+         duration={convert.msToMinsAndSecs(track.duration_ms)}
+      />
+    )
   }
 
   render() {
 
     return(
       <div>
-        "Welcome to Tracks Index Container"
+        <br></br>
+        {this.getTrackIndexTiles()}
       </div>
     )
   }


### PR DESCRIPTION
Utilize Spotify tracks API endpoint to get info on up to 50 tracks at a time. Call this with track_ids in the db for user. Display relevant info on tracks index page with styling.