### PR TITLE
Create edit functionality

### DIFF
--- a/app/assets/stylesheets/track_index.css
+++ b/app/assets/stylesheets/track_index.css
@@ -13,9 +13,9 @@
 }
 
 .index-tile .wrapper:hover {
-    cursor: pointer;
-    background: rgba(0, 0, 0, 0.25);
-    box-shadow: 1px 1px 1px rgba(72, 72, 72, 0.88);
+  cursor: pointer;
+  background: rgba(0, 0, 0, 0.25);
+  box-shadow: 1px 1px 1px rgba(72, 72, 72, 0.88);
 }
 
 .index-tile .wrapper img{
@@ -70,9 +70,15 @@
 .edit-delete {
   margin-top: 1em;
   width: 20%;
+  background-color: #333333;
+  opacity: .8;
 }
 
-.hey {
+.edit-delete:hover {
+  background-color: #49adc1;
+}
+
+.edit-delete-wrapper {
   padding-right: 20em;
   padding-left: 20em;
 }

--- a/app/assets/stylesheets/track_index.css
+++ b/app/assets/stylesheets/track_index.css
@@ -82,3 +82,12 @@
   padding-right: 20em;
   padding-left: 20em;
 }
+
+.edit-form {
+  padding-top: 1em;
+}
+
+.edit-x {
+  padding-left: 2em;
+  font-size: 22px;
+}

--- a/app/controllers/api/v1/user_track_categories_controller.rb
+++ b/app/controllers/api/v1/user_track_categories_controller.rb
@@ -13,6 +13,36 @@ class Api::V1::UserTrackCategoriesController < ApiController
     end
   end
 
+  def edit; end
+
+  def update
+    errors = false
+    user_track_params = {user_id: params[:user_id], track_id: params[:id]}
+    previous_categories = UserTrackCategory.where(user_track_params).pluck(:category_id)
+    selected_categories = params[:categories]
+    previous_categories.each do |category_id|
+      if !selected_categories.include?(category_id)
+        user_track_category_to_destroy = UserTrackCategory.where({user_id: params[:user_id], track_id: params[:id], category_id: category_id}).first
+        user_track_category_to_destroy.destroy
+      end
+    end
+    selected_categories.each do |category_id|
+      if !previous_categories.include?(category_id)
+        new_user_track_category = UserTrackCategory.new({user_id: params[:user_id], track_id: params[:id], category_id: category_id})
+        if !new_user_track_category.save
+          errors = true
+        end
+      end
+    end
+
+    if !errors
+      render json: {success: "Track edited successfully!"}
+    else
+      render json: {error: "Error: Something went wrong while editing your track!"}
+    end
+
+  end
+
   def create
     errors = false
     categories = params[:categories]

--- a/app/javascript/react/clients/track.js
+++ b/app/javascript/react/clients/track.js
@@ -26,6 +26,15 @@ const deleteTrack = (userId, trackId) => fetch(
   }
 );
 
+const editTrack = (userId, trackId, payload) => fetch(
+  `${USER_TRACK_CATEGORY_PATH}/${userId}/user_track_categories/${trackId}.json`,
+  {
+    ...defaultOptions,
+    body: JSON.stringify(payload),
+    method: 'PATCH'
+  }
+);
+
 const get = userId => fetch(
   `${USER_TRACK_CATEGORY_PATH}/${userId}/user_track_categories.json`,
   defaultOptions
@@ -34,5 +43,6 @@ const get = userId => fetch(
 export default {
   post: post,
   deleteTrack: deleteTrack,
+  editTrack: editTrack,
   get: get
 };

--- a/app/javascript/react/components/TrackIndexTile.js
+++ b/app/javascript/react/components/TrackIndexTile.js
@@ -1,7 +1,8 @@
 import React from 'react'
 
 const TrackIndexTile = props => {
-  let editDiv;
+
+  let editDiv
   let hideForEdit = "";
 
   if (props.editMode) {
@@ -23,8 +24,8 @@ const TrackIndexTile = props => {
          );
       })
 
-    editDiv = <form onSubmit={props.handleSubmit}>
-      <br></br>
+    editDiv = <form className="edit-form" onSubmit={props.handleSubmit}>
+      <i className="fas fa-times edit-x" onClick={props.cancelEdit}></i>
       <div className="row">
         <div className="columns small-8 small-centered">
            <div className="row">
@@ -38,6 +39,7 @@ const TrackIndexTile = props => {
     </form>
 
   } else {
+
     const checkBoxDiv = props.allCategories.map(category => {
         return (
           <div key={category.id} className="columns small-3">
@@ -53,6 +55,7 @@ const TrackIndexTile = props => {
           </div>
          );
       })
+
     editDiv = <div className="row">
       <div className="columns small-8 small-centered">
          <div className="row">

--- a/app/javascript/react/components/TrackIndexTile.js
+++ b/app/javascript/react/components/TrackIndexTile.js
@@ -1,21 +1,66 @@
 import React from 'react'
 
 const TrackIndexTile = props => {
+  let editDiv;
+  let hideForEdit = "";
 
-  const categoryCheckBoxes = props.allCategories.map(category => {
-    return (
-      <div key={category.id} className="columns small-3">
-        <label className="container">
-          {category.name}
-          <input
-            type="checkbox"
-            checked={props.trackCategories.includes(category.id)}
-          />
-          <div className="checkmark"></div>
-        </label>
+  if (props.editMode) {
+    hideForEdit = "hidden";
+
+    const checkBoxDiv = props.allCategories.map(category => {
+        return (
+          <div key={category.id} className="columns small-3">
+            <label className="container">
+              {category.name}
+              <input
+                type="checkbox"
+                checked={props.trackCategories.includes(category.id)}
+                onChange={() => props.handleInputChange(category.id)}
+              />
+              <div className="checkmark"></div>
+            </label>
+          </div>
+         );
+      })
+
+    editDiv = <form onSubmit={props.handleSubmit}>
+      <br></br>
+      <div className="row">
+        <div className="columns small-8 small-centered">
+           <div className="row">
+             {checkBoxDiv}
+           </div>
+        </div>
       </div>
-     );
-  })
+      <div className="row text-center">
+        <button type="submit" value="Submit" className="form-save">Save</button>
+      </div>
+    </form>
+
+  } else {
+    const checkBoxDiv = props.allCategories.map(category => {
+        return (
+          <div key={category.id} className="columns small-3">
+            <label className="container">
+              {category.name}
+              <input
+                type="checkbox"
+                checked={props.trackCategories.includes(category.id)}
+                readOnly={true}
+              />
+              <div className="checkmark"></div>
+            </label>
+          </div>
+         );
+      })
+    editDiv = <div className="row">
+      <div className="columns small-8 small-centered">
+         <div className="row">
+           {checkBoxDiv}
+         </div>
+      </div>
+    </div>
+  }
 
   return (
     <div className="index-tile">
@@ -29,17 +74,15 @@ const TrackIndexTile = props => {
       </span>
       <div className={props.hidden}>
         <span className="small-12 columns wrapper">
-          {categoryCheckBoxes}
-          <div className="row text-center hey">
-            <button className="small-2 columns edit-delete">Edit</button>
+          {editDiv}
+          <div className={`row text-center edit-delete-wrapper ${hideForEdit}`}>
+            <button className="small-2 columns edit-delete" onClick={props.handleEditClick}>Edit</button>
             <button className="small-2 columns edit-delete" onClick={props.handleDelete}>Delete</button>
           </div>
         </span>
       </div>
-
     </div>
   )
 }
-
 
 export default TrackIndexTile

--- a/app/javascript/react/components/TrackIndexTile.js
+++ b/app/javascript/react/components/TrackIndexTile.js
@@ -1,6 +1,22 @@
 import React from 'react'
 
 const TrackIndexTile = props => {
+
+  const categoryCheckBoxes = props.allCategories.map(category => {
+    return (
+      <div key={category.id} className="columns small-3">
+        <label className="container">
+          {category.name}
+          <input
+            type="checkbox"
+            checked={props.trackCategories.includes(category.id)}
+          />
+          <div className="checkmark"></div>
+        </label>
+      </div>
+     );
+  })
+
   return (
     <div className="index-tile">
       <span className="small-12 columns wrapper">
@@ -13,6 +29,7 @@ const TrackIndexTile = props => {
       </span>
       <div className={props.hidden}>
         <span className="small-12 columns wrapper">
+          {categoryCheckBoxes}
           <div className="row text-center hey">
             <button className="small-2 columns edit-delete">Edit</button>
             <button className="small-2 columns edit-delete" onClick={props.handleDelete}>Delete</button>

--- a/app/javascript/react/constants.js
+++ b/app/javascript/react/constants.js
@@ -1,2 +1,5 @@
 export const JWT = 'jwt'
 export const USER = 'user'
+export const CANCEL_EDIT_MESSAGE = 'Are you sure you want to cancel editing this track? Any changes will not be saved!'
+export const DELETE_MESSAGE = 'Are you sure you want to delete this track?'
+export const NO_CATEGORY_MESSAGE = 'You must select one or more categories!'

--- a/app/javascript/react/containers/NewTrackContainer.js
+++ b/app/javascript/react/containers/NewTrackContainer.js
@@ -4,7 +4,7 @@ import TrackForm from './TrackForm';
 import convert from '../util/convert';
 import createArtistList from '../util/createArtistList';
 import storage from '../util/storage';
-import { JWT, USER } from '../constants';
+import { JWT, USER, NO_CATEGORY_MESSAGE } from '../constants';
 import trackClient from '../clients/track';
 
 class NewTrackContainer extends React.Component {
@@ -67,7 +67,7 @@ class NewTrackContainer extends React.Component {
     }
     else {
       this.setState({
-        saveMessage: "You must select one or more categories!"
+        saveMessage: NO_CATEGORY_MESSAGE
       })
     }
   }

--- a/app/javascript/react/containers/TrackPlayer.js
+++ b/app/javascript/react/containers/TrackPlayer.js
@@ -67,6 +67,10 @@ class TrackPlayer extends React.Component {
     this.getWeatherData();
   }
 
+  componentWillUnmount() {
+    this.state.player.disconnect();
+  }
+
   render() {
     const currentTrack = this.state.playerState && this.state.playerState.track_window.current_track;
 

--- a/app/javascript/react/containers/TracksIndexContainer.js
+++ b/app/javascript/react/containers/TracksIndexContainer.js
@@ -14,12 +14,20 @@ class TracksIndexContainer extends React.Component {
       tracks: [],
       droppedDownTracks: [],
       changeMessage: null,
-      allCategories: []
+      allCategories: [],
+      editMode: [],
+      selectedCategories: {},
+      edited: []
     }
 
     this.getTrackIndexTiles = this.getTrackIndexTiles.bind(this);
     this.dropDownTrack = this.dropDownTrack.bind(this);
     this.deleteTrack = this.deleteTrack.bind(this);
+    this.editTrack = this.editTrack.bind(this);
+    this.handleEditClick = this.handleEditClick.bind(this);
+    this.onSelectCategory = this.onSelectCategory.bind(this);
+    this.getStoredCategories = this.getStoredCategories.bind(this);
+    this.getSelectedCategories = this.getSelectedCategories.bind(this);
   }
 
   componentDidMount() {
@@ -35,11 +43,11 @@ class TracksIndexContainer extends React.Component {
       .catch(error => console.error(`Error in fetch: ${error.message}`));
     categoryClient.get()
       .then(response => response.json())
-      .then(body =>
+      .then(body => {
         this.setState({
           allCategories: body.categories
         })
-      )
+      })
       .catch(error => console.error(`Error in fetch: ${error.message}`));
   }
 
@@ -79,6 +87,72 @@ class TracksIndexContainer extends React.Component {
     }
   }
 
+  editTrack(event, trackId, categoryIds) {
+    event.preventDefault();
+    const userId = storage.get(USER).id;
+    const payload = {
+      categories: categoryIds
+    }
+    trackClient.editTrack(userId, trackId, payload)
+      .then(response  => response.json())
+      .then(body => {
+        if(body.success) {
+         this.state.edited.push(trackId)
+         this.setState({
+           changeMessage: body.success,
+           droppedDownTracks: this.state.droppedDownTracks.filter(id => id !== trackId),
+           edited: this.state.edited,
+           editMode: this.state.editMode.filter(id => id !== trackId)
+         })
+       } else {
+         this.setState({
+           changeMessage: body.error
+         })
+       }
+      })
+      .catch(error => console.error(`Error in fetch: ${error.message}`))
+  }
+
+  getStoredCategories(id) {
+    const track = this.state.tracks.find(track => track.id === id)
+    return track.categories.map(category => category.id)
+  }
+
+  handleEditClick(id) {
+    this.state.editMode.push(id)
+    let obj = this.state.selectedCategories
+    obj[id] = this.getStoredCategories(id)
+    this.setState({
+      editMode: this.state.editMode,
+      selectedCategories: obj
+    })
+  }
+
+  getSelectedCategories(id) {
+    if (!this.state.editMode.includes(id) && !this.state.edited.includes(id)) {
+      return this.getStoredCategories(id)
+    } else {
+      return this.state.selectedCategories[id]
+    }
+  }
+
+  onSelectCategory(trackId, categoryId) {
+    const { selectedCategories } = this.state;
+
+    if(selectedCategories[trackId].includes(categoryId)) {
+      const updatedCategories = selectedCategories[trackId].filter(id => id !== categoryId)
+      selectedCategories[trackId] = updatedCategories
+      this.setState({
+        selectedCategories: selectedCategories
+      })
+    } else {
+      selectedCategories[trackId].push(categoryId)
+      this.setState({
+        selectedCategories: selectedCategories
+      })
+    }
+  }
+
   getTrackIndexTiles() {
     return this.state.tracks.map(track => {
       let hidden, dropDownIcon;
@@ -100,8 +174,12 @@ class TracksIndexContainer extends React.Component {
          dropDownIcon={dropDownIcon}
          dropDownTrack={() => this.dropDownTrack(track.id)}
          handleDelete={() => this.deleteTrack(track.id)}
+         handleEditClick={() => this.handleEditClick(track.id)}
+         editMode={this.state.editMode.includes(track.id)}
          allCategories={this.state.allCategories}
-         trackCategories={track.categories.map(category => category.id)}
+         trackCategories={this.getSelectedCategories(track.id)}
+         handleInputChange={(categoryId) => this.onSelectCategory(track.id, categoryId)}
+         handleSubmit={(event) => this.editTrack(event, track.id, this.state.selectedCategories[track.id])}
       />
     })
   }
@@ -110,8 +188,10 @@ class TracksIndexContainer extends React.Component {
 
     return(
       <div>
-        <div className="save-message">
-          {this.state.changeMessage}
+        <div className="text-center">
+          <div className="save-message">
+            {this.state.changeMessage}
+          </div>
         </div>
         <div className="index-labels">
           <span className="title">TITLE</span>

--- a/app/javascript/react/containers/TracksIndexContainer.js
+++ b/app/javascript/react/containers/TracksIndexContainer.js
@@ -3,6 +3,7 @@ import TrackIndexTile from '../components/TrackIndexTile';
 import convert from '../util/convert';
 import createArtistList from '../util/createArtistList';
 import trackClient from '../clients/track';
+import categoryClient from '../clients/category';
 import storage from '../util/storage';
 import { USER } from '../constants';
 
@@ -12,7 +13,8 @@ class TracksIndexContainer extends React.Component {
     this.state = {
       tracks: [],
       droppedDownTracks: [],
-      changeMessage: null
+      changeMessage: null,
+      allCategories: []
     }
 
     this.getTrackIndexTiles = this.getTrackIndexTiles.bind(this);
@@ -30,6 +32,14 @@ class TracksIndexContainer extends React.Component {
           tracks: tracks
         })
       })
+      .catch(error => console.error(`Error in fetch: ${error.message}`));
+    categoryClient.get()
+      .then(response => response.json())
+      .then(body =>
+        this.setState({
+          allCategories: body.categories
+        })
+      )
       .catch(error => console.error(`Error in fetch: ${error.message}`));
   }
 
@@ -90,6 +100,8 @@ class TracksIndexContainer extends React.Component {
          dropDownIcon={dropDownIcon}
          dropDownTrack={() => this.dropDownTrack(track.id)}
          handleDelete={() => this.deleteTrack(track.id)}
+         allCategories={this.state.allCategories}
+         trackCategories={track.categories.map(category => category.id)}
       />
     })
   }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :login, only: [:index]
       resources :user, only: [:create] do
-        resources :user_track_categories, only: [:create, :index, :destroy]
+        resources :user_track_categories, only: [:create, :index, :destroy, :update]
       end
       resources :categories, only: [:index]
       resources :weather, only: [:index]


### PR DESCRIPTION
Users can now edit which categories a track belongs to on the track index page. They can see what categories the track belongs to on the index tile, and then can click edit to enter the 'edit mode' where they can actually change the checkboxes. Users have the option of cancelling out of this edit. Also on this PR, made it so that the spotify player is disconnecting when umounting from the player page to fix the bug in which multiple tracks play on top of eachother as a result of returning to the player page.